### PR TITLE
support multiple removals in helm; no longer dep on dash

### DIFF
--- a/gnus-recent-helm.el
+++ b/gnus-recent-helm.el
@@ -47,12 +47,21 @@
   (helm :sources `(((name . "Gnus recent articles")
                     (candidates . ,(mapcar (lambda (item)
                                              (cons (car item) item))
-                                           gnus-recent--articles-list)) 
+                                           gnus-recent--articles-list))
                     (action . (("Open article"               . gnus-recent--open-article)
                                ("Copy org link to kill ring" . gnus-recent-kill-new-org-link)
                                ("Insert org link"            . gnus-recent-insert-org-link)
-                               ("Remove article"             . gnus-recent-forget)))))
+                               ("Remove article"             . gnus-recent-helm-forget)))))
         :buffer "*helm gnus recent*"))
+
+(defun gnus-recent-helm-forget (_recent)
+  "Remove Gnus articles from `gnus-recent--articles-list' using `helm'.
+Helm allows for marked articles or current selection. See
+function `helm-marked-candidates'. Argument _recent is not used."
+  (let ((cand (helm-marked-candidates)))
+    (dolist (article cand)
+      (cl-delete article gnus-recent--articles-list :test 'equal :count 1))
+    (message "Removed %d article(s) from gnus-recent" (length cand))))
 
 (provide 'gnus-recent-helm)
 

--- a/gnus-recent.el
+++ b/gnus-recent.el
@@ -46,7 +46,6 @@
 ;;; Code:
 
 (require 'gnus-sum)
-(require 'dash)
 
 (defvar gnus-recent--articles-list nil
   "The list of articles read in this Emacs session.")
@@ -106,7 +105,7 @@ moved article was already tracked.  For use by
 `gnus-summary-article-move-hook'."
   (when (eq action 'move)
     (let ((article-data (gnus-recent--get-article-data)))
-      (cl-nsubstitute (-replace-at 2 to-group article-data)
+      (cl-nsubstitute (list (first article-data) (second article-data) to-group) 
                       article-data
                       gnus-recent--articles-list
                       :test 'equal :count 1))))
@@ -185,7 +184,8 @@ Warn if RECENT can't be deconstructed as expected."
 
 (defun gnus-recent-kill-new-org-link (recent)
   "Add to the `kill-ring' an `org-mode' link to RECENT Gnus article."
-  (kill-new (gnus-recent--create-org-link recent)))
+  (kill-new (gnus-recent--create-org-link recent))
+  (message "Added org-link to kill-ring"))
 
 (defun gnus-recent-insert-org-link (recent)
   "Insert an `org-mode' link to RECENT Gnus article."
@@ -193,9 +193,8 @@ Warn if RECENT can't be deconstructed as expected."
 
 (defun gnus-recent-forget (recent)
   "Remove RECENT Gnus article from `gnus-recent--articles-list'."
-  (setq gnus-recent--articles-list
-        (delete recent gnus-recent--articles-list))
-  (message "Removed %s from `gnus-recent--articles-list'" (car recent)))
+  (cl-delete recent gnus-recent--articles-list :test 'equal :count 1)
+    (message "Removed %s from gnus-recent articles" (car recent)))
 
 
 (provide 'gnus-recent)


### PR DESCRIPTION
* Removed the use of the dash library

Dash library was used only in one place, easy to remove the extra dependency.

* new function gnus-recent-helm-forget to handle action forget for helm

Helm can do actions on one or multiple marked items. The new function can handle
both cases when applying the 'forget' action. This allows the user to remove
multiple articles from gnus-recent--articles-list in one step.

* replace delete with cl-delete in gnus-recent-forget

cl-delete operates destructively, therefore avoiding an extra setq operation and it
has a count parameter, so after a match is stops further searching.